### PR TITLE
Fix/variable product price sync

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1535,7 +1535,7 @@ class Settings {
 				'filter'             => '',
 				'pricesale_discount' => '',
 				'filter_sku'         => '',
-				'tax_option'         => 'no',
+				'tax_price'          => 'no',
 				'rates'              => 'default',
 				'catnp'              => 'yes',
 				'doctype'            => 'invoice',
@@ -1868,7 +1868,7 @@ class Settings {
 	 * @return void
 	 */
 	public function tax_option_callback() {
-		$tax_price = isset( $this->settings['tax'] ) ? $this->settings['tax'] : 'no';
+		$tax_price = isset( $this->settings['tax_price'] ) ? $this->settings['tax_price'] : 'no';
 		?>
 		<select name="connect_ecommerce[<?php echo esc_html( $this->connector ); ?>][tax_price]" id="wcsen_tax">
 			<option value="yes" <?php selected( $tax_price, 'yes' ); ?>><?php esc_html_e( 'Yes, tax included', 'woocommerce-es' ); ?></option>

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -290,6 +290,7 @@ class PROD {
 			'length'           => isset( $item['lenght'] ) ? $item['lenght'] : '',
 			'width'            => isset( $item['width'] ) ? $item['width'] : '',
 			'height'           => isset( $item['height'] ) ? $item['height'] : '',
+			'tax_class'        => isset( $item['tax_type'] ) ? $item['tax_type'] : '',
 		);
 
 		if ( 'variable' !== $type ) {
@@ -315,7 +316,7 @@ class PROD {
 				'date_on_sale_to'    => '',
 				'total_sales'        => '',
 				'tax_status'         => 'taxable',
-				'tax_class'          => '',
+				'tax_class'          => isset( $item['tax_type'] ) ? $item['tax_type'] : '',
 				'manage_stock'       => 'yes' === $import_stock ? true : false,
 				'stock_quantity'     => null,
 				'sold_individually'  => false,

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -287,15 +287,20 @@ class PROD {
 		$product_props     = array(
 			'stock_status'     => 'instock',
 			'backorders'       => $allow_backorders,
-			'regular_price'    => self::get_rate_price( $item, $rate_id ),
 			'length'           => isset( $item['lenght'] ) ? $item['lenght'] : '',
 			'width'            => isset( $item['width'] ) ? $item['width'] : '',
 			'height'           => isset( $item['height'] ) ? $item['height'] : '',
 		);
+
+		if ( 'variable' !== $type ) {
+			$product_props['regular_price'] = self::get_rate_price( $item, $rate_id );
+		}
+
 		$price_sale = self::get_sale_price( $item, $settings );
-		if ( ! empty( $price_sale ) ) {
+		if ( ! empty( $price_sale ) && 'variable' !== $type ) {
 			$product_props['sale_price'] = $price_sale;
 		}
+
 		$product_props_new = array();
 		if ( $is_new_product ) {
 			$product_props_new = array(

--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,10 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 
 == Changelog ==
 
+= 3.3.4 =
+* Fixed: Tax prices setting key corrected from `tax_option` to `tax_price` — prices with tax included were not being imported correctly.
+* Fixed: Tax class from ERP tax type is now correctly applied on both product create and update (NEO connector).
+
 = 3.3.3 =
 * Enhancement: Improved order sync scheduling — prevents duplicate async jobs by checking for pending Action Scheduler actions before scheduling a new one.
 * Fixed: Admin CSS and WooCommerce schedule action on purchase.

--- a/tests/WooCommerce/CreateProductVariableTest.php
+++ b/tests/WooCommerce/CreateProductVariableTest.php
@@ -165,8 +165,8 @@ class CreateProductVariableTest extends WP_UnitTestCase {
 		$this->assertIsInt( $result_sync_upd['post_id'] );
 		$this->assertEquals( $result_prod_id, $result_sync_upd['post_id'] );
 
-		// Prices.
-		$this->assertEquals( $item['price'], get_post_meta( $result_sync_upd['post_id'], '_regular_price', true ) );
+		// Variable parent has no regular_price — price is derived from variations.
+		$this->assertEmpty( get_post_meta( $result_sync_upd['post_id'], '_regular_price', true ) );
 
 		// Product update does not change Title and Content.
 		$this->assertEquals( 'Updated Product Title', get_the_title( $result_sync_upd['post_id'] ) );

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -5,7 +5,7 @@
  * Description:       Connects Ecommerce WooCommerce to ERPs and CRMs. Syncs products, customers, orders and stock. Includes EU VAT Compliance. Import European Taxes and check VAT compliance.
  * Author:            Closetechnology
  * Author URI:        https://close.technology/
- * Version:           3.3.3
+ * Version:           3.3.4-beta.1
  * Requires PHP:      7.4
  * Requires at least: 6.3
  * Text Domain:       woocommerce-es
@@ -20,7 +20,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CONECOM_VERSION', '3.3.3' );
+define( 'CONECOM_VERSION', '3.3.4-beta.1' );
 define( 'CONECOM_FILE', __FILE__ );
 define( 'CONECOM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONECOM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fshop%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fwoocommerce-es%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-173-92a4f25aabc72b5f7c5d41c9379c4749598dc3d4.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22woocommerce%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->