### PR TITLE
Add VAT field to user profile with checkout sync

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"\nimport re, sys, json\nreadme = 'readme.txt'\ntry:\n    with open(readme, 'r', encoding='utf-8') as f:\n        content = f.read()\nexcept FileNotFoundError:\n    sys.exit(0)\n\nhas_next = bool(re.search(r'^= next =$', content, re.MULTILINE))\nif not has_next:\n    match = re.search(r'^= \\d+\\.\\d+', content, re.MULTILINE)\n    if match:\n        content = content[:match.start()] + '= next =\\n* \\n\\n' + content[match.start():]\n        with open(readme, 'w', encoding='utf-8') as f:\n            f.write(content)\n        msg = 'Changelog: created = next = section in readme.txt — add your entry now.'\n    else:\n        msg = 'Changelog reminder: add an entry to the = next = section in readme.txt.'\nelse:\n    next_block = re.search(r'^= next =\\n(.*?)(?=^= \\d|\\Z)', content, re.MULTILINE | re.DOTALL)\n    entries = [l for l in (next_block.group(1) if next_block else '').splitlines() if l.strip() and l.strip() != '*']\n    if not entries:\n        msg = 'Changelog reminder: = next = section in readme.txt is empty — describe what changed.'\n    else:\n        sys.exit(0)\n\nprint(json.dumps({'systemMessage': msg}))\n\"",
+            "timeout": 10,
+            "statusMessage": "Checking changelog..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/includes/Frontend/MyAccount.php
+++ b/includes/Frontend/MyAccount.php
@@ -81,6 +81,17 @@ class MyAccount {
 		add_filter( 'woocommerce_account_orders_columns', array( $this, 'add_account_orders_column' ), 10, 1 );
 		add_action( 'woocommerce_my_account_my_orders_column_custom-column', array( $this, 'add_account_orders_column_rows' ) );
 		add_action( 'wp_ajax_cwc_document_download', array( $this, 'cwc_document_download' ) );
+
+		// VAT field on user profile and pre-population.
+		$settings_public = get_option( 'connect_ecommerce_public' );
+		$show_vat        = isset( $settings_public['vat_show'] ) ? $settings_public['vat_show'] : 'yes';
+		if ( 'yes' === $show_vat ) {
+			add_action( 'show_user_profile', array( $this, 'show_vat_profile_field' ) );
+			add_action( 'edit_user_profile', array( $this, 'show_vat_profile_field' ) );
+			add_action( 'personal_options_update', array( $this, 'save_vat_profile_field' ) );
+			add_action( 'edit_user_profile_update', array( $this, 'save_vat_profile_field' ) );
+			add_action( 'woocommerce_checkout_update_customer', array( $this, 'sync_vat_to_user_meta' ), 10, 2 );
+		}
 	}
 
 	/**
@@ -160,5 +171,80 @@ class MyAccount {
 		readfile( $file_document_path );
 
 		wp_die();
+	}
+
+	/**
+	 * Display the VAT number field on the user profile page.
+	 *
+	 * @param WP_User $user User object.
+	 * @return void
+	 */
+	public function show_vat_profile_field( $user ) {
+		$vat_number = get_user_meta( $user->ID, 'billing_vat', true );
+		?>
+		<h3><?php esc_html_e( 'Billing VAT', 'woocommerce-es' ); ?></h3>
+		<table class="form-table">
+			<tr>
+				<th><label for="billing_vat"><?php esc_html_e( 'VAT Number', 'woocommerce-es' ); ?></label></th>
+				<td>
+					<input type="text"
+						name="billing_vat"
+						id="billing_vat"
+						value="<?php echo esc_attr( $vat_number ); ?>"
+						class="regular-text"
+					/>
+				</td>
+			</tr>
+		</table>
+		<?php
+	}
+
+	/**
+	 * Save the VAT number from the user profile page.
+	 *
+	 * @param int $user_id User ID being saved.
+	 * @return void
+	 */
+	public function save_vat_profile_field( $user_id ) {
+		if ( ! current_user_can( 'edit_user', $user_id ) ) {
+			return;
+		}
+		$vat_number = isset( $_POST['billing_vat'] ) ? sanitize_text_field( wp_unslash( $_POST['billing_vat'] ) ) : '';
+		update_user_meta( $user_id, 'billing_vat', $vat_number );
+	}
+
+	/**
+	 * Sync billing_vat to user meta after checkout so future orders pre-populate the field.
+	 *
+	 * @param WC_Customer $customer  WooCommerce customer object.
+	 * @param array       $data      Posted checkout data.
+	 * @return void
+	 */
+	public function sync_vat_to_user_meta( $customer, $data ) {
+		$user_id = $customer->get_id();
+		if ( ! $user_id ) {
+			return;
+		}
+
+		$vat_number = '';
+		foreach ( CONECOM_VAT_FIELD_SLUGS as $slug ) {
+			if ( 'VAT Number' === $slug ) {
+				continue;
+			}
+			$key   = str_replace( '_billing_', 'billing_', ltrim( $slug, '_' ) );
+			$value = isset( $data[ $key ] ) ? $data[ $key ] : '';
+			if ( empty( $value ) ) {
+				// Also check the namespaced blocks field.
+				$value = isset( $data['connect_ecommerce/billing_vat'] ) ? $data['connect_ecommerce/billing_vat'] : '';
+			}
+			if ( ! empty( $value ) ) {
+				$vat_number = $value;
+				break;
+			}
+		}
+
+		if ( ! empty( $vat_number ) ) {
+			update_user_meta( $user_id, 'billing_vat', sanitize_text_field( $vat_number ) );
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,9 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 
 == Changelog ==
 
+= 3.3.4 =
+* Enhancement: Added billing VAT number field to the WordPress user profile page (/wp-admin/profile.php and /wp-admin/user-edit.php). Admins can now view and edit the VAT number directly on a customer's profile. The value is stored as `billing_vat` user meta, so WooCommerce pre-populates the field automatically on the public checkout and on admin order creation for logged-in customers.
+
 = 3.3.3 =
 * Enhancement: Improved order sync scheduling — prevents duplicate async jobs by checking for pending Action Scheduler actions before scheduling a new one.
 * Fixed: Admin CSS and WooCommerce schedule action on purchase.

--- a/tests/Unit/MyAccountVATProfileTest.php
+++ b/tests/Unit/MyAccountVATProfileTest.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Class MyAccountVATProfileTest
+ *
+ * Command: composer test -- --filter=MyAccountVATProfileTest
+ *
+ * @package Connect_Ecommerce
+ */
+
+use CLOSE\ConnectEcommerce\Frontend\MyAccount;
+
+class MyAccountVATProfileTest extends WP_UnitTestCase {
+	/**
+	 * MyAccount instance.
+	 *
+	 * @var MyAccount
+	 */
+	private $my_account;
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Set up test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option(
+			'connect_ecommerce_public',
+			array(
+				'vat_show'      => 'yes',
+				'vat_mandatory' => 'no',
+			)
+		);
+
+		$this->user_id = self::factory()->user->create(
+			array(
+				'role' => 'customer',
+			)
+		);
+
+		$this->my_account = new MyAccount(
+			array(
+				'settings_all' => array(),
+				'connector'    => '',
+				'settings'     => array(),
+				'all_options'  => array(),
+				'options'      => array(),
+				'connapi_erp'  => null,
+			)
+		);
+	}
+
+	/**
+	 * Tear down test environment.
+	 */
+	public function tearDown(): void {
+		wp_delete_user( $this->user_id );
+		parent::tearDown();
+	}
+
+	/**
+	 * Saving a VAT number via save_vat_profile_field() persists it as user meta.
+	 */
+	public function test_save_vat_profile_field_stores_user_meta() {
+		wp_set_current_user( $this->user_id );
+		$_POST['billing_vat'] = 'ESB12345678';
+
+		$this->my_account->save_vat_profile_field( $this->user_id );
+
+		$stored = get_user_meta( $this->user_id, 'billing_vat', true );
+		$this->assertEquals( 'ESB12345678', $stored );
+	}
+
+	/**
+	 * save_vat_profile_field() sanitises the input (strips tags/scripts).
+	 */
+	public function test_save_vat_profile_field_sanitises_value() {
+		wp_set_current_user( $this->user_id );
+		$_POST['billing_vat'] = '<script>alert(1)</script>ESB12345678';
+
+		$this->my_account->save_vat_profile_field( $this->user_id );
+
+		$stored = get_user_meta( $this->user_id, 'billing_vat', true );
+		$this->assertEquals( 'ESB12345678', $stored );
+	}
+
+	/**
+	 * save_vat_profile_field() clears the meta when an empty value is submitted.
+	 */
+	public function test_save_vat_profile_field_clears_empty_value() {
+		update_user_meta( $this->user_id, 'billing_vat', 'ESB12345678' );
+		wp_set_current_user( $this->user_id );
+		$_POST['billing_vat'] = '';
+
+		$this->my_account->save_vat_profile_field( $this->user_id );
+
+		$stored = get_user_meta( $this->user_id, 'billing_vat', true );
+		$this->assertEmpty( $stored );
+	}
+
+	/**
+	 * show_vat_profile_field() outputs an input with the current stored value.
+	 */
+	public function test_show_vat_profile_field_renders_existing_value() {
+		update_user_meta( $this->user_id, 'billing_vat', 'ESB12345678' );
+		$user = get_userdata( $this->user_id );
+
+		ob_start();
+		$this->my_account->show_vat_profile_field( $user );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'billing_vat', $output );
+		$this->assertStringContainsString( 'ESB12345678', $output );
+	}
+
+	/**
+	 * show_vat_profile_field() renders an empty input when no meta is stored.
+	 */
+	public function test_show_vat_profile_field_renders_empty_when_no_meta() {
+		$user = get_userdata( $this->user_id );
+
+		ob_start();
+		$this->my_account->show_vat_profile_field( $user );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'billing_vat', $output );
+		$this->assertStringContainsString( 'value=""', $output );
+	}
+
+	/**
+	 * sync_vat_to_user_meta() writes billing_vat to user meta from checkout data.
+	 */
+	public function test_sync_vat_to_user_meta_saves_from_checkout_data() {
+		$customer = $this->getMockBuilder( 'stdClass' )
+			->addMethods( array( 'get_id' ) )
+			->getMock();
+		$customer->method( 'get_id' )->willReturn( $this->user_id );
+
+		$data = array( 'billing_vat' => 'ESB87654321' );
+
+		$this->my_account->sync_vat_to_user_meta( $customer, $data );
+
+		$stored = get_user_meta( $this->user_id, 'billing_vat', true );
+		$this->assertEquals( 'ESB87654321', $stored );
+	}
+
+	/**
+	 * sync_vat_to_user_meta() does nothing when customer has no user ID (guest).
+	 */
+	public function test_sync_vat_to_user_meta_skips_guest() {
+		$customer = $this->getMockBuilder( 'stdClass' )
+			->addMethods( array( 'get_id' ) )
+			->getMock();
+		$customer->method( 'get_id' )->willReturn( 0 );
+
+		$data = array( 'billing_vat' => 'ESB87654321' );
+
+		$this->my_account->sync_vat_to_user_meta( $customer, $data );
+
+		// No user meta should be written for a guest (user ID 0).
+		$stored = get_user_meta( 0, 'billing_vat', true );
+		$this->assertEmpty( $stored );
+	}
+
+	/**
+	 * Profile hooks are registered when vat_show is enabled.
+	 */
+	public function test_profile_hooks_registered_when_vat_enabled() {
+		$this->assertGreaterThan(
+			0,
+			has_action( 'show_user_profile', array( $this->my_account, 'show_vat_profile_field' ) )
+		);
+		$this->assertGreaterThan(
+			0,
+			has_action( 'edit_user_profile', array( $this->my_account, 'show_vat_profile_field' ) )
+		);
+		$this->assertGreaterThan(
+			0,
+			has_action( 'personal_options_update', array( $this->my_account, 'save_vat_profile_field' ) )
+		);
+		$this->assertGreaterThan(
+			0,
+			has_action( 'edit_user_profile_update', array( $this->my_account, 'save_vat_profile_field' ) )
+		);
+	}
+
+	/**
+	 * Profile hooks are NOT registered when vat_show is disabled.
+	 */
+	public function test_profile_hooks_not_registered_when_vat_disabled() {
+		update_option( 'connect_ecommerce_public', array( 'vat_show' => 'no' ) );
+
+		$instance = new MyAccount(
+			array(
+				'settings_all' => array(),
+				'connector'    => '',
+				'settings'     => array(),
+				'all_options'  => array(),
+				'options'      => array(),
+				'connapi_erp'  => null,
+			)
+		);
+
+		$this->assertFalse(
+			has_action( 'show_user_profile', array( $instance, 'show_vat_profile_field' ) )
+		);
+		$this->assertFalse(
+			has_action( 'personal_options_update', array( $instance, 'save_vat_profile_field' ) )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Extends VAT field management to the WordPress user profile page, allowing administrators to view and edit VAT numbers directly on user accounts. Adds automatic synchronization of VAT data from checkout to user meta for pre-population on future orders.

## Changes

- **VAT field on user profile**: Display and edit VAT number (`billing_vat` meta) on both `show_user_profile` and `edit_user_profile` screens, with proper capability checks
- **Profile field persistence**: Save VAT number from user profile updates via `personal_options_update` and `edit_user_profile_update` hooks
- **Checkout-to-profile sync**: New `sync_vat_to_user_meta()` method hooks into `woocommerce_checkout_update_customer` to capture VAT data from checkout and store it in user meta, enabling pre-population on subsequent orders
- **Conditional registration**: All new functionality is gated behind the `vat_show` setting check (only registers hooks if enabled)

## Implementation Details

- VAT field uses standard WordPress user meta key `billing_vat` for consistency with WooCommerce billing fields
- Sync method iterates through `CONECOM_VAT_FIELD_SLUGS` to handle multiple field name variants (classic checkout + block checkout namespaced fields)
- Proper input sanitization (`sanitize_text_field`, `wp_unslash`) and capability checks (`current_user_can`) applied throughout
- All new methods follow existing code style conventions (tabs, Yoda conditions, documentation blocks)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fshop%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fwoocommerce-es%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-178-171a1841cb52ae359593f0045102f6cdec5fb8e6.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22woocommerce%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->