### PR TITLE
Add WordPress Playground preview workflows for PRs

### DIFF
--- a/.github/workflows/pr-playground-preview-publish.yml
+++ b/.github/workflows/pr-playground-preview-publish.yml
@@ -1,0 +1,116 @@
+name: PR Playground Preview Publish
+
+# Publishes the read-only build artifact from "PR Playground Preview Build" and
+# writes the Playground button to the PR. This workflow must not check out or
+# execute pull request code.
+
+on:
+  workflow_run:
+    workflows:
+      - PR Playground Preview Build
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  playground-preview:
+    name: Publish Playground preview button
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download Playground preview metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name woocommerce-es-preview-metadata \
+            --dir preview-metadata
+
+      - name: Read Playground preview metadata
+        id: metadata
+        run: |
+          pr_number="$(cat preview-metadata/pr-number)"
+          head_sha="$(cat preview-metadata/head-sha)"
+
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number in preview metadata: $pr_number" >&2
+            exit 1
+          fi
+
+          if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid head SHA in preview metadata: $head_sha" >&2
+            exit 1
+          fi
+
+          echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head-sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Expose built artifact as a public URL
+        id: expose
+        uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
+        with:
+          artifact-name:              woocommerce-es-zip
+          artifact-filename:          woocommerce-es.zip
+          artifact-source-run-id:     ${{ github.event.workflow_run.id }}
+          artifact-source-repository: ${{ github.repository }}
+          pr-number:                  ${{ steps.metadata.outputs.pr-number }}
+          commit-sha:                 ${{ steps.metadata.outputs.head-sha }}
+          artifacts-to-keep:          '2'
+          github-token:               ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Playground blueprint
+        id: blueprint
+        env:
+          ARTIFACT_URL: ${{ steps.expose.outputs.artifact-url }}
+        run: |
+          node - <<'NODE' >> "$GITHUB_OUTPUT"
+          const url = process.env.ARTIFACT_URL;
+          if (!url) {
+            throw new Error('ARTIFACT_URL is required');
+          }
+          const blueprint = {
+            "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+            landingPage: "/shop",
+            phpExtensionBundles: [ "kitchen-sink" ],
+            steps: [
+              {
+                step: "login",
+                username: "admin",
+                password: "password",
+              },
+              {
+                step: "installPlugin",
+                pluginZipFile: {
+                  resource: "url",
+                  url,
+                },
+                options: { activate: true },
+              },
+              {
+                step: "installPlugin",
+                pluginZipFile: {
+                  resource: "wordpress.org/plugins",
+                  slug: "woocommerce",
+                },
+                options: { activate: true },
+              },
+            ],
+          };
+          console.log(`blueprint=${JSON.stringify(blueprint)}`);
+          NODE
+
+      - name: Post Playground Preview Button
+        uses: WordPress/action-wp-playground-pr-preview@v2
+        with:
+          mode:         append-to-description
+          blueprint:    ${{ steps.blueprint.outputs.blueprint }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number:    ${{ steps.metadata.outputs.pr-number }}

--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -1,0 +1,72 @@
+name: PR Playground Preview Build
+
+# Builds a plugin zip for every pull request. A separate workflow_run
+# publisher exposes the artifact and posts the Playground preview button, so
+# forked PRs can be supported without running untrusted PR code with write
+# permissions.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Playground preview artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer
+          coverage: none
+
+      - name: Install production Composer dependencies
+        run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress
+
+      - name: Build plugin zip honouring .distignore
+        env:
+          PLUGIN_SLUG: woocommerce-es
+        run: |
+          mkdir -p "build/${PLUGIN_SLUG}"
+          rsync -a --delete \
+            --exclude-from='.distignore' \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='build' \
+            ./ "build/${PLUGIN_SLUG}/"
+          cd build
+          zip -qr "${PLUGIN_SLUG}.zip" "${PLUGIN_SLUG}"
+          ls -lh "${PLUGIN_SLUG}.zip"
+
+      - name: Write Playground preview metadata
+        run: |
+          mkdir -p build/playground-preview
+          printf '%s' '${{ github.event.pull_request.number }}' > build/playground-preview/pr-number
+          printf '%s' '${{ github.event.pull_request.head.sha }}' > build/playground-preview/head-sha
+
+      - name: Upload plugin zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: woocommerce-es-zip
+          path: build/woocommerce-es.zip
+          if-no-files-found: error
+          retention-days: 5
+
+      - name: Upload Playground preview metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: woocommerce-es-preview-metadata
+          path: build/playground-preview
+          if-no-files-found: error
+          retention-days: 5


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows to enable WordPress Playground preview functionality for pull requests. This allows reviewers to test plugin changes directly in a browser-based WordPress environment without local setup.

## Key Changes

- **`pr-playground-preview.yml`** — Build workflow triggered on PR events (opened, synchronize, reopened, edited)
  - Checks out PR code with minimal permissions (`contents: read` only)
  - Installs production Composer dependencies
  - Builds a plugin zip file respecting `.distignore`
  - Uploads the zip artifact and metadata (PR number, commit SHA) for 5-day retention

- **`pr-playground-preview-publish.yml`** — Publish workflow triggered on successful build completion
  - Downloads the build artifact in a separate, privileged context
  - Validates PR metadata (PR number and commit SHA)
  - Exposes the artifact as a public URL via WordPress Playground action
  - Generates a Playground blueprint that:
    - Logs in as admin
    - Installs the built plugin (woocommerce-es) and activates it
    - Installs and activates WooCommerce
    - Navigates to `/shop` on load
    - Includes kitchen-sink PHP extensions
  - Posts a Playground preview button to the PR description

## Implementation Details

- Follows security best practice: untrusted PR code runs with read-only permissions; artifact publishing and PR commenting happen in a separate workflow with elevated permissions
- Uses WordPress Playground's official action (`WordPress/action-wp-playground-pr-preview`) for URL exposure and button posting
- Metadata validation ensures only valid PR numbers and commit SHAs are processed
- Artifacts are retained for 5 days and limited to 2 most recent builds to manage storage

https://claude.ai/code/session_01G58gLYcayWZCHh65ipWsza