### PR TITLE
Fix discounts and Payload

### DIFF
--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -14,7 +14,6 @@ defined( 'ABSPATH' ) || exit;
 
 use CLOSE\ConnectEcommerce\Helpers\ORDER;
 use CLOSE\ConnectEcommerce\Helpers\HELPER;
-use CLOSE\ConnectEcommerce\Helpers\VAT;
 
 /**
  * Class Orders integration

--- a/includes/Admin/Widget_Order.php
+++ b/includes/Admin/Widget_Order.php
@@ -12,7 +12,6 @@ namespace CLOSE\ConnectEcommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
-use CLOSE\ConnectEcommerce\Base;
 /**
  * Widget in Orders
  *
@@ -65,6 +64,9 @@ class Widget_Order {
 			'side',
 			'core'
 		);
+
+		// Register log payload metabox only when the meta is not empty.
+		add_action( 'add_meta_boxes_' . $screen, array( $this, 'maybe_add_log_payload_metabox' ) );
 	}
 
 	/**
@@ -102,5 +104,60 @@ class Widget_Order {
 		echo '</td></tr>';
 
 		echo '</table>';
+	}
+
+	/**
+	 * Conditionally registers the log payload metabox when the meta is not empty.
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return void
+	 */
+	public function maybe_add_log_payload_metabox( $post ) {
+		$is_debug = isset( $this->options['debug_log'] ) && 'on' === $this->options['debug_log'];
+
+		if ( ! $is_debug ) {
+			return;
+		}
+
+		$order       = wc_get_order( $post->ID );
+		$payload_key = '_' . $this->options['slug'] . '_log_payload';
+
+		if ( empty( $order ) || empty( $order->get_meta( $payload_key, true ) ) ) {
+			return;
+		}
+
+		$screen = get_current_screen()->id == 'woocommerce_page_wc-orders' ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
+
+		add_meta_box(
+			'cw-order-log-payload',
+			__( 'Connect Log Payload', 'woocommerce-es' ),
+			array( $this, 'metabox_show_log_payload' ),
+			$screen,
+			'normal',
+			'low'
+		);
+	}
+
+	/**
+	 * Metabox showing the log payload JSON for the order.
+	 *
+	 * @param object $post Post object.
+	 * @return void
+	 */
+	public function metabox_show_log_payload( $post ) {
+		$order       = wc_get_order( $post->ID );
+		$payload_key = '_' . $this->options['slug'] . '_log_payload';
+		$log_payload = $order->get_meta( $payload_key, true );
+
+		if ( empty( $log_payload ) ) {
+			return;
+		}
+
+		$decoded = json_decode( $log_payload, true );
+		$json    = null !== $decoded ? wp_json_encode( $decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE ) : $log_payload;
+
+		echo '<pre style="overflow:auto;max-height:300px;font-size:11px;background:#f6f7f7;padding:8px;border:1px solid #ddd;border-radius:3px;white-space:pre-wrap;word-break:break-all;">';
+		echo esc_html( $json );
+		echo '</pre>';
 	}
 }

--- a/includes/Admin/Widget_Order.php
+++ b/includes/Admin/Widget_Order.php
@@ -28,6 +28,13 @@ class Widget_Order {
 	private $options;
 
 	/**
+	 * Settings saved by the user (credentials, debug_log, etc.).
+	 *
+	 * @var array
+	 */
+	private $settings;
+
+	/**
 	 * API Object
 	 *
 	 * @var object
@@ -44,6 +51,7 @@ class Widget_Order {
 			return;
 		}
 		$this->options     = $connector['options'];
+		$this->settings    = $connector['settings'] ?? array();
 		$this->connapi_erp = $connector['connapi_erp'];
 		// Register Meta box for post type product.
 		add_action( 'add_meta_boxes', array( $this, 'metabox_orders' ) );
@@ -113,7 +121,7 @@ class Widget_Order {
 	 * @return void
 	 */
 	public function maybe_add_log_payload_metabox( $post ) {
-		$is_debug = isset( $this->options['debug_log'] ) && 'on' === $this->options['debug_log'];
+		$is_debug = isset( $this->settings['debug_log'] ) && 'on' === $this->settings['debug_log'];
 
 		if ( ! $is_debug ) {
 			return;

--- a/includes/Helpers/ORDER.php
+++ b/includes/Helpers/ORDER.php
@@ -78,6 +78,9 @@ class ORDER {
 				$order->update_meta_data( $meta_key_order, $invoice_id );
 				$order->update_meta_data( '_' . $option_prefix . '_doc_id', $doc_id );
 				$order->update_meta_data( '_' . $option_prefix . '_doc_type', $doctype );
+				if ( $is_debug_log && isset( $result['log_payload'] ) ) {
+					$order->update_meta_data( '_' . $option_prefix . '_log_payload', $result['log_payload'] );
+				}
 				$order->save();
 
 				$order_msg = __( 'Order synced correctly with ERP, ID: ', 'woocommerce-es' ) . $invoice_id;
@@ -324,7 +327,7 @@ class ORDER {
 					}
 					$product_cost                            = floatval( $item['line_total'] );
 					$fields_items[ $index_bund ]['subtotal'] = $fields_items[ $index_bund ]['subtotal'] + $product_cost;
-					$fields_items[ $index_bund ]['tax']      = round( $vat_per, 2 );
+					$fields_items[ $index_bund ]['tax']      = (float) number_format( $vat_per, 2, '.', '' );
 				}
 			} else {
 				$item_qty   = (int) $item->get_quantity();
@@ -334,7 +337,7 @@ class ORDER {
 					'name'      => $item->get_name(),
 					'desc'      => get_the_excerpt( $product_id ),
 					'units'     => $item_qty,
-					'subtotal'  => (float) $price_line,
+					'subtotal'  => (float) number_format( $price_line, 2, '.', '' ),
 					'sku'       => ! empty( $product ) ? $product->get_sku() : '',
 					'image_url' => get_the_post_thumbnail_url( $product_id, 'post-thumbnail' ),
 					'permalink' => get_the_permalink( $product_id ),
@@ -348,14 +351,12 @@ class ORDER {
 				$line_discount = $item->get_subtotal() - $item->get_total();
 				if ( $line_discount > 0 ) {
 					$coupon = array_search( (string) $line_discount, array_column( $order_discounts, 'discount' ), true );
-					if ( false !== $coupon ) {
-						$coupon_type = $order_discounts[ $coupon ]['type'];
-						if ( 'percent' === $coupon_type ) {
-							// Percentage discount.
-							$line_discount = (float) $order_discounts[ $coupon ]['amount'];
-						}
+					if ( false !== $coupon && 'percent' === $order_discounts[ $coupon ]['type'] ) {
+						// Percentage discount: amount is already the percentage value.
+						$item_data['discount'] = (float) number_format( (float) $order_discounts[ $coupon ]['amount'], 2, '.', '' );
+					} else {
+						$item_data['discount'] = (float) number_format( ( $line_discount * 100 ) / $item->get_subtotal(), 2, '.', '' );
 					}
-					$item_data['discount'] = round( ( $line_discount * 100 ) / $item->get_subtotal(), 2 );
 				}
 
 				$fields_items[] = $item_data;
@@ -446,7 +447,7 @@ class ORDER {
 			if ( ! empty( $tax_key ) ) {
 				$item_taxes['taxes'] = array( trim( $tax_key ) );
 			} else {
-				$item_taxes['tax']     = ! empty( $item_tax_data['total'][ $tax_rate_id_from_item ] ) ? round( $item_tax_data['total'][ $tax_rate_id_from_item ], 2 ) : 0;
+				$item_taxes['tax']     = ! empty( $item_tax_data['total'][ $tax_rate_id_from_item ] ) ? (float) number_format( (float) $item_tax_data['total'][ $tax_rate_id_from_item ], 2, '.', '' ) : 0;
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,9 +4,9 @@ Tags: connect, integrate, eu vat, vat compliance, woocommerce
 Donate link: https://close.marketing/go/donate/
 Requires at least: 5.0
 Requires PHP: 7.4
-Tested up to: 6.9
-Stable tag: 3.3.3
-Version: 3.3.3
+Tested up to: 7.0
+Stable tag: 3.3.4
+Version: 3.3.4
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,11 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 
 == Changelog ==
 
+= next =
+* Fixed: Order item `tax` and `discount` values no longer expose IEEE 754 floating-point noise (e.g. `2.1000000000000001` or `33.329999999999998`) in the JSON payload sent to the ERP. All values are now serialized with at most 2 decimal digits.
+* Fixed: Fixed-cart coupon discount is now correctly distributed as a percentage across all order lines.
+* Added: Log payload metabox (Connect Log Payload) is now saved and shown only when Debug Mode is active in the plugin settings.
+
 = 3.3.3 =
 * Enhancement: Improved order sync scheduling — prevents duplicate async jobs by checking for pending Action Scheduler actions before scheduling a new one.
 * Fixed: Admin CSS and WooCommerce schedule action on purchase.

--- a/tests/WooCommerce/CreateOrderTest.php
+++ b/tests/WooCommerce/CreateOrderTest.php
@@ -545,8 +545,72 @@ class CreateOrderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test percent coupon discount sends the percentage value, not a recalculated amount.
+	 *
+	 * Regression test for the bug introduced in v3.3.3 where a 20% coupon on a $16
+	 * item produced discount=125 instead of discount=20, causing Holded to return
+	 * negative totals (16 × (1 − 1.25) = −4.00).
+	 */
+	public function test_percent_coupon_discount_sends_percentage_not_recalculated_amount() {
+		// Create a product with subtotal $16.
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 16 );
+		$product->save();
+
+		// Create a percent coupon of 20%.
+		$coupon = new \WC_Coupon();
+		$coupon->set_code( 'percent20' );
+		$coupon->set_discount_type( 'percent' );
+		$coupon->set_amount( 20 );
+		$coupon->save();
+
+		// Create an order.
+		$order = new \WC_Order();
+		$order->set_billing_email( 'test@example.com' );
+		$order->set_status( 'completed' );
+
+		// Add product: subtotal $16, total $12.80 after 20% discount.
+		$item = new \WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 1 );
+		$item->set_subtotal( 16 );
+		$item->set_total( 12.80 );
+		$order->add_item( $item );
+
+		// Add the percent coupon line item: discount monetary amount = 3.20.
+		$coupon_item = new \WC_Order_Item_Coupon();
+		$coupon_item->set_code( 'percent20' );
+		$coupon_item->set_discount( 3.20 );
+		$order->add_item( $coupon_item );
+
+		$order->calculate_totals();
+		$order->save();
+
+		$option_prefix = 'conecom-test';
+		$order_data    = ORDER::generate_order_data( $this->settings, $order, $option_prefix );
+
+		$this->assertNotEmpty( $order_data['items'] );
+		$first_item = $order_data['items'][0];
+
+		$this->assertArrayHasKey( 'discount', $first_item, 'Item should have a discount field' );
+
+		// Must be 20 (the coupon percentage), not 125 (the wrong recalculated value).
+		$this->assertEquals(
+			20.0,
+			$first_item['discount'],
+			'Percent coupon discount must send the percentage value (20), not the recalculated amount (125)'
+		);
+
+		// Clean up.
+		$product->delete( true );
+		$coupon->delete( true );
+		$order->delete( true );
+	}
+
+	/**
 	 * Test rounding precision for discounts (Issue #138)
-	 * 
+	 *
 	 * Verifies that discount percentages are rounded to 2 decimals instead of 0 decimals.
 	 */
 	public function test_order_discount_rounding_precision() {
@@ -637,6 +701,237 @@ class CreateOrderTest extends WP_UnitTestCase {
 			$coupon->delete( true );
 			$order->delete( true );
 		}
+	}
+
+	/**
+	 * Test fixed_cart coupon (e.g. €10 off) distributes discount across all order lines.
+	 *
+	 * WooCommerce distributes a fixed cart coupon proportionally by line subtotal.
+	 * The discount field sent to the ERP must be a percentage per line, not the raw
+	 * monetary amount, and must be rounded to 2 decimals.
+	 *
+	 * Example: €10 coupon on a cart with two items (€30 + €20 = €50 subtotal).
+	 *   - Item A gets €6 off  → discount = (6/30)*100 = 20.00%
+	 *   - Item B gets €4 off  → discount = (4/20)*100 = 20.00%
+	 */
+	public function test_fixed_cart_coupon_discount_distributes_to_all_lines() {
+		// Product A: €30, Product B: €20.
+		$product_a = new \WC_Product_Simple();
+		$product_a->set_name( 'Product A' );
+		$product_a->set_regular_price( 30 );
+		$product_a->save();
+
+		$product_b = new \WC_Product_Simple();
+		$product_b->set_name( 'Product B' );
+		$product_b->set_regular_price( 20 );
+		$product_b->save();
+
+		// Fixed cart coupon: €10 off.
+		$coupon = new \WC_Coupon();
+		$coupon->set_code( 'cart10' );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		// Build the order manually, distributing the €10 discount proportionally:
+		//   €50 subtotal → Item A (60%) gets €6 off, Item B (40%) gets €4 off.
+		$order = new \WC_Order();
+		$order->set_billing_email( 'test@example.com' );
+		$order->set_status( 'completed' );
+
+		$item_a = new \WC_Order_Item_Product();
+		$item_a->set_product( $product_a );
+		$item_a->set_quantity( 1 );
+		$item_a->set_subtotal( 30 );
+		$item_a->set_total( 24 ); // 30 - 6.
+		$order->add_item( $item_a );
+
+		$item_b = new \WC_Order_Item_Product();
+		$item_b->set_product( $product_b );
+		$item_b->set_quantity( 1 );
+		$item_b->set_subtotal( 20 );
+		$item_b->set_total( 16 ); // 20 - 4.
+		$order->add_item( $item_b );
+
+		// Coupon line item carries the full €10 monetary discount.
+		$coupon_item = new \WC_Order_Item_Coupon();
+		$coupon_item->set_code( 'cart10' );
+		$coupon_item->set_discount( 10 );
+		$order->add_item( $coupon_item );
+
+		$order->calculate_totals();
+		$order->save();
+
+		$option_prefix = 'conecom-test';
+		$order_data    = ORDER::generate_order_data( $this->settings, $order, $option_prefix );
+
+		$this->assertNotEmpty( $order_data['items'], 'Order must have items' );
+		$this->assertCount( 2, $order_data['items'], 'Order must have exactly 2 product lines' );
+
+		$item_data_a = $order_data['items'][0];
+		$item_data_b = $order_data['items'][1];
+
+		// Both items must carry a discount field.
+		$this->assertArrayHasKey( 'discount', $item_data_a, 'Item A must have a discount field' );
+		$this->assertArrayHasKey( 'discount', $item_data_b, 'Item B must have a discount field' );
+
+		// Item A: (6 / 30) * 100 = 20.00%.
+		$this->assertEquals( 20.0, $item_data_a['discount'], 'Item A discount must be 20.00%' );
+
+		// Item B: (4 / 20) * 100 = 20.00%.
+		$this->assertEquals( 20.0, $item_data_b['discount'], 'Item B discount must be 20.00%' );
+
+		// Discount values must be proper floats, not strings.
+		$this->assertIsFloat( $item_data_a['discount'] );
+		$this->assertIsFloat( $item_data_b['discount'] );
+
+		// Discount values must not expose IEEE 754 extra decimals.
+		$this->assertEquals(
+			(float) number_format( $item_data_a['discount'], 2, '.', '' ),
+			$item_data_a['discount'],
+			'Item A discount must be rounded to 2 decimals'
+		);
+		$this->assertEquals(
+			(float) number_format( $item_data_b['discount'], 2, '.', '' ),
+			$item_data_b['discount'],
+			'Item B discount must be rounded to 2 decimals'
+		);
+
+		// Clean up.
+		$product_a->delete( true );
+		$product_b->delete( true );
+		$coupon->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that fixed_cart coupon discount and tax values have at most 2 decimal digits
+	 * when serialized, i.e. no IEEE 754 trailing noise like 33.329999999999998.
+	 *
+	 * Uses prices that are known to produce non-terminating binary fractions:
+	 *   - €15 item, 21% tax   → tax = 3.15  (exact in decimal, tricky in binary)
+	 *   - €10 fixed coupon on a €45 cart → Item A (€30): 6.67% off, Item B (€15): 6.67% off
+	 */
+	public function test_fixed_cart_coupon_discount_and_tax_have_max_2_decimals() {
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+
+		$tax_rate_id = \WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => 'ES',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '21.0000',
+				'tax_rate_name'     => 'IVA',
+				'tax_rate_priority' => 1,
+				'tax_rate_compound' => 0,
+				'tax_rate_shipping' => 0,
+				'tax_rate_order'    => 0,
+				'tax_rate_class'    => '',
+			)
+		);
+
+		// Product A: €30, Product B: €15 — total cart €45.
+		$product_a = new \WC_Product_Simple();
+		$product_a->set_name( 'Product Float A' );
+		$product_a->set_regular_price( 30 );
+		$product_a->set_tax_status( 'taxable' );
+		$product_a->set_tax_class( '' );
+		$product_a->save();
+
+		$product_b = new \WC_Product_Simple();
+		$product_b->set_name( 'Product Float B' );
+		$product_b->set_regular_price( 15 );
+		$product_b->set_tax_status( 'taxable' );
+		$product_b->set_tax_class( '' );
+		$product_b->save();
+
+		// Fixed cart coupon: €10 off.
+		$coupon = new \WC_Coupon();
+		$coupon->set_code( 'cart10float' );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		// Distribute €10 proportionally: A gets €6.67, B gets €3.33.
+		$discount_a = round( 10 * ( 30 / 45 ), 2 ); // 6.67
+		$discount_b = round( 10 * ( 15 / 45 ), 2 ); // 3.33
+		$tax_a      = round( 30 * 0.21, 2 );         // 6.30
+		$tax_b      = round( 15 * 0.21, 2 );         // 3.15
+
+		$order = new \WC_Order();
+		$order->set_billing_email( 'float@example.com' );
+		$order->set_billing_country( 'ES' );
+		$order->set_status( 'completed' );
+
+		$item_a = new \WC_Order_Item_Product();
+		$item_a->set_product( $product_a );
+		$item_a->set_quantity( 1 );
+		$item_a->set_subtotal( 30 );
+		$item_a->set_total( 30 - $discount_a );
+		$item_a->set_taxes( array(
+			'total'    => array( $tax_rate_id => $tax_a ),
+			'subtotal' => array( $tax_rate_id => $tax_a ),
+		) );
+		$order->add_item( $item_a );
+
+		$item_b = new \WC_Order_Item_Product();
+		$item_b->set_product( $product_b );
+		$item_b->set_quantity( 1 );
+		$item_b->set_subtotal( 15 );
+		$item_b->set_total( 15 - $discount_b );
+		$item_b->set_taxes( array(
+			'total'    => array( $tax_rate_id => $tax_b ),
+			'subtotal' => array( $tax_rate_id => $tax_b ),
+		) );
+		$order->add_item( $item_b );
+
+		$coupon_item = new \WC_Order_Item_Coupon();
+		$coupon_item->set_code( 'cart10float' );
+		$coupon_item->set_discount( 10 );
+		$order->add_item( $coupon_item );
+
+		$order->calculate_totals();
+		$order->save();
+
+		$order_data = ORDER::generate_order_data( $this->settings, $order, 'conecom-test' );
+
+		$this->assertNotEmpty( $order_data['items'] );
+		$this->assertCount( 2, $order_data['items'] );
+
+		foreach ( $order_data['items'] as $i => $item ) {
+			$label = "Item $i";
+
+			// Discount must be present and must be a float.
+			$this->assertArrayHasKey( 'discount', $item, "$label must have discount" );
+			$this->assertIsFloat( $item['discount'], "$label discount must be float" );
+
+			// Tax must be present and must be a float.
+			$this->assertArrayHasKey( 'tax', $item, "$label must have tax" );
+			$this->assertIsFloat( $item['tax'], "$label tax must be float" );
+
+			// Neither value may have more than 2 significant decimal digits.
+			// json_encode exposes IEEE 754 noise — serialize and check the string.
+			$discount_json = json_encode( $item['discount'] );
+			$tax_json      = json_encode( $item['tax'] );
+
+			$this->assertMatchesRegularExpression(
+				'/^-?\d+(\.\d{1,2})?$/',
+				$discount_json,
+				"$label discount JSON '$discount_json' must have at most 2 decimal digits"
+			);
+			$this->assertMatchesRegularExpression(
+				'/^-?\d+(\.\d{1,2})?$/',
+				$tax_json,
+				"$label tax JSON '$tax_json' must have at most 2 decimal digits"
+			);
+		}
+
+		// Clean up.
+		$product_a->delete( true );
+		$product_b->delete( true );
+		$coupon->delete( true );
+		$order->delete( true );
+		\WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -5,7 +5,7 @@
  * Description:       Connects Ecommerce WooCommerce to ERPs and CRMs. Syncs products, customers, orders and stock. Includes EU VAT Compliance. Import European Taxes and check VAT compliance.
  * Author:            Closetechnology
  * Author URI:        https://close.technology/
- * Version:           3.3.4-beta.1
+ * Version:           3.3.4
  * Requires PHP:      7.4
  * Requires at least: 6.3
  * Text Domain:       woocommerce-es
@@ -20,7 +20,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CONECOM_VERSION', '3.3.4-beta.1' );
+define( 'CONECOM_VERSION', '3.3.4' );
 define( 'CONECOM_FILE', __FILE__ );
 define( 'CONECOM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONECOM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -5,7 +5,7 @@
  * Description:       Connects Ecommerce WooCommerce to ERPs and CRMs. Syncs products, customers, orders and stock. Includes EU VAT Compliance. Import European Taxes and check VAT compliance.
  * Author:            Closetechnology
  * Author URI:        https://close.technology/
- * Version:           3.3.3
+ * Version:           3.3.4-beta.1
  * Requires PHP:      7.4
  * Requires at least: 6.3
  * Text Domain:       woocommerce-es
@@ -20,7 +20,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CONECOM_VERSION', '3.3.3' );
+define( 'CONECOM_VERSION', '3.3.4-beta.1' );
 define( 'CONECOM_FILE', __FILE__ );
 define( 'CONECOM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONECOM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fshop%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fwoocommerce-es%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-190-4ad8ec340a44e9cbf5cd422701f2156fd07dab90.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22woocommerce%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->